### PR TITLE
Feature/ Replace lane-based battlefield with radial coordinate system

### DIFF
--- a/UnityProject/BrainAcademy/Assets/Editor/Setup/SceneBuilderSnake.cs
+++ b/UnityProject/BrainAcademy/Assets/Editor/Setup/SceneBuilderSnake.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 
 /// <summary>
-/// Builds SnakeSpellScene with HUD, battlefield panel (3 lanes),
+/// Builds SnakeSpellScene with HUD, radial battlefield panel,
 /// question panel, answer buttons, overlays, and feedback.
 /// </summary>
 public static class SceneBuilderSnake
@@ -12,8 +12,6 @@ public static class SceneBuilderSnake
     private static readonly Color Background = new Color(0.94f, 0.96f, 0.97f);
     private static readonly Color Purple60 = new Color(0.40f, 0.49f, 0.92f);
     private static readonly Color GrassLight = new Color(0.49f, 0.78f, 0.31f);  // #7EC850
-    private static readonly Color GrassDark = new Color(0.36f, 0.68f, 0.23f);   // #5DAE3B
-    private static readonly Color DirtRoad = AppColors.DirtRoad;
 
     public static void Build()
     {
@@ -49,60 +47,34 @@ public static class SceneBuilderSnake
             new Vector2(0, 0.48f), new Vector2(1, 0.93f),
             new Vector2(0.5f, 0.5f), Vector2.zero, Vector2.zero);
 
-        // 3 lane backgrounds
-        var laneImages = new Image[3];
-        var dirtImages = new Image[3];
-        var wizardRTs = new RectTransform[3];
-
-        for (int i = 0; i < 3; i++)
+        // Single battlefield background
+        var bgObj = UIFactory.CreateImage(battlefield.transform,
+            "BattlefieldBackground", GrassLight, Vector2.zero);
+        UIFactory.Stretch(bgObj);
+        var bgImage = bgObj.GetComponent<Image>();
+        if (PrefabFactory.GrassLightSprite != null)
         {
-            float yMin = 1f - (i + 1) / 3f;
-            float yMax = 1f - i / 3f;
-
-            // Lane background
-            bool evenLane = i % 2 == 0;
-            var lane = UIFactory.CreateImage(battlefield.transform,
-                $"Lane{i}", evenLane ? GrassLight : GrassDark,
-                Vector2.zero);
-            UIFactory.SetRect(lane, new Vector2(0, yMin), new Vector2(1, yMax),
-                new Vector2(0.5f, 0.5f), Vector2.zero, Vector2.zero);
-            var laneImg = lane.GetComponent<Image>();
-            Sprite grassSprite = evenLane ? PrefabFactory.GrassLightSprite : PrefabFactory.GrassDarkSprite;
-            if (grassSprite != null)
-            {
-                laneImg.sprite = grassSprite;
-                laneImg.color = Color.white;
-            }
-            laneImages[i] = laneImg;
-
-            // Dirt road (lane divider strip at bottom of lane)
-            var dirt = UIFactory.CreateImage(battlefield.transform,
-                $"DirtRoad{i}", DirtRoad, Vector2.zero);
-            UIFactory.SetRect(dirt, new Vector2(0, yMin), new Vector2(1, yMin + 0.04f),
-                new Vector2(0.5f, 0), Vector2.zero, Vector2.zero);
-            dirtImages[i] = dirt.GetComponent<Image>();
-
-            // Wizard (left side of each lane)
-            var wizard = new GameObject($"Wizard{i}", typeof(Image));
-            wizard.transform.SetParent(battlefield.transform, false);
-            var wizImg = wizard.GetComponent<Image>();
-            wizImg.preserveAspect = true;
-            if (PrefabFactory.WizardSprite != null)
-            {
-                wizImg.sprite = PrefabFactory.WizardSprite;
-                wizImg.color = Color.white;
-            }
-            else
-            {
-                wizImg.color = Purple60;
-            }
-            // Flip horizontally so wizard faces right (toward snakes)
-            wizard.transform.localScale = new Vector3(-1, 1, 1);
-            var wrt = UIFactory.SetRect(wizard,
-                new Vector2(0, yMin), new Vector2(0, yMax),
-                new Vector2(0, 0.5f), new Vector2(50, 0), new Vector2(90, 0));
-            wizardRTs[i] = wrt;
+            bgImage.sprite = PrefabFactory.GrassLightSprite;
+            bgImage.color = Color.white;
         }
+
+        // Single wizard centered
+        var wizard = new GameObject("Wizard", typeof(Image));
+        wizard.transform.SetParent(battlefield.transform, false);
+        var wizImg = wizard.GetComponent<Image>();
+        wizImg.preserveAspect = true;
+        if (PrefabFactory.WizardSprite != null)
+        {
+            wizImg.sprite = PrefabFactory.WizardSprite;
+            wizImg.color = Color.white;
+        }
+        else
+        {
+            wizImg.color = Purple60;
+        }
+        var wizRT = UIFactory.SetRect(wizard,
+            new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
+            new Vector2(0.5f, 0.5f), Vector2.zero, new Vector2(90, 90));
 
         // Wave transition overlay
         var waveOverlay = new GameObject("WaveTransitionOverlay", typeof(RectTransform));
@@ -216,12 +188,8 @@ public static class SceneBuilderSnake
         var bfRend = bfRendGo.AddComponent<BattlefieldRenderer>();
 
         UIFactory.Wire(bfRend, "battlefieldPanel", bfRT);
-        UIFactory.WireList(bfRend, "laneBackgrounds",
-            new Object[] { laneImages[0], laneImages[1], laneImages[2] });
-        UIFactory.WireList(bfRend, "dirtRoads",
-            new Object[] { dirtImages[0], dirtImages[1], dirtImages[2] });
-        UIFactory.WireList(bfRend, "wizardObjects",
-            new Object[] { wizardRTs[0], wizardRTs[1], wizardRTs[2] });
+        UIFactory.Wire(bfRend, "battlefieldBackground", bgImage);
+        UIFactory.Wire(bfRend, "wizardObject", wizRT);
         UIFactory.Wire(bfRend, "snakePrefab", PrefabFactory.SnakePrefab);
         UIFactory.Wire(bfRend, "spellPrefab", PrefabFactory.SpellPrefab);
         UIFactory.Wire(bfRend, "waveTransitionOverlay", waveOverlay);
@@ -241,10 +209,6 @@ public static class SceneBuilderSnake
             UIFactory.Wire(bfRend, "snakePurpleSprite", PrefabFactory.SnakePurpleSprite);
         if (PrefabFactory.SpellSprite != null)
             UIFactory.Wire(bfRend, "spellSprite", PrefabFactory.SpellSprite);
-        if (PrefabFactory.GrassLightSprite != null)
-            UIFactory.Wire(bfRend, "grassLightSprite", PrefabFactory.GrassLightSprite);
-        if (PrefabFactory.GrassDarkSprite != null)
-            UIFactory.Wire(bfRend, "grassDarkSprite", PrefabFactory.GrassDarkSprite);
 
         EditorSceneManager.SaveScene(scene, "Assets/Scenes/SnakeSpellScene.unity");
         Debug.Log("[Setup] SnakeSpellScene built");

--- a/UnityProject/BrainAcademy/Assets/Scripts/Models/SnakeSpellConstants.cs
+++ b/UnityProject/BrainAcademy/Assets/Scripts/Models/SnakeSpellConstants.cs
@@ -1,6 +1,6 @@
 public static class SnakeSpellConstants
 {
-    public const float FieldWidth = 1000f;
-    public const float WizardX = 40f;
-    public const int NumLanes = 3;
+    public const float FieldRadius = 500f;
+    public const float WizardHitRadius = 30f;
+    public const float SpellDespawnRadius = 520f;
 }

--- a/UnityProject/BrainAcademy/Assets/Scripts/Models/SnakeSpellModels.cs
+++ b/UnityProject/BrainAcademy/Assets/Scripts/Models/SnakeSpellModels.cs
@@ -65,18 +65,18 @@ public static class SnakeTypeData
 public class SnakeData
 {
     public int id;
-    public int lane;
+    public float angleDeg;
     public SnakeType type;
-    public float xPosition;
+    public float distance;
     public int hp;
     public float speed;
 
-    public SnakeData(int id, int lane, SnakeType type, float xPosition, int hp, float speed)
+    public SnakeData(int id, float angleDeg, SnakeType type, float distance, int hp, float speed)
     {
         this.id = id;
-        this.lane = lane;
+        this.angleDeg = angleDeg;
         this.type = type;
-        this.xPosition = xPosition;
+        this.distance = distance;
         this.hp = hp;
         this.speed = speed;
     }
@@ -85,16 +85,16 @@ public class SnakeData
 public class SpellData
 {
     public int id;
-    public int lane;
-    public float xPosition;
+    public float angleDeg;
+    public float distance;
     public int targetSnakeId;
     public float speed;
 
-    public SpellData(int id, int lane, float xPosition, int targetSnakeId, float speed = 400f)
+    public SpellData(int id, float angleDeg, float distance, int targetSnakeId, float speed = 400f)
     {
         this.id = id;
-        this.lane = lane;
-        this.xPosition = xPosition;
+        this.angleDeg = angleDeg;
+        this.distance = distance;
         this.targetSnakeId = targetSnakeId;
         this.speed = speed;
     }

--- a/UnityProject/BrainAcademy/Assets/Scripts/SnakeSpell/BattlefieldRenderer.cs
+++ b/UnityProject/BrainAcademy/Assets/Scripts/SnakeSpell/BattlefieldRenderer.cs
@@ -7,12 +7,11 @@ public class BattlefieldRenderer : MonoBehaviour
     [Header("Battlefield Panel")]
     [SerializeField] private RectTransform battlefieldPanel;
 
-    [Header("Lane Backgrounds")]
-    [SerializeField] private List<Image> laneBackgrounds;
-    [SerializeField] private List<Image> dirtRoads;
+    [Header("Background")]
+    [SerializeField] private Image battlefieldBackground;
 
-    [Header("Wizards")]
-    [SerializeField] private List<RectTransform> wizardObjects;
+    [Header("Wizard")]
+    [SerializeField] private RectTransform wizardObject;
 
     [Header("Prefabs")]
     [SerializeField] private GameObject snakePrefab;
@@ -25,8 +24,6 @@ public class BattlefieldRenderer : MonoBehaviour
     [SerializeField] private Sprite snakeRedSprite;
     [SerializeField] private Sprite snakePurpleSprite;
     [SerializeField] private Sprite spellSprite;
-    [SerializeField] private Sprite grassLightSprite;
-    [SerializeField] private Sprite grassDarkSprite;
 
     [Header("Overlays")]
     [SerializeField] private GameObject waveTransitionOverlay;
@@ -47,38 +44,14 @@ public class BattlefieldRenderer : MonoBehaviour
         controller = FindObjectOfType<SnakeSpellController>();
         GenerateCircleSprite();
 
-        // Set lane backgrounds (use sprites if available, otherwise colors)
-        for (int i = 0; i < laneBackgrounds.Count && i < SnakeSpellConstants.NumLanes; i++)
+        // Set wizard sprite if available
+        if (wizardObject != null && wizardSprite != null)
         {
-            bool even = i % 2 == 0;
-            var laneImg = laneBackgrounds[i];
-            Sprite grassSprite = even ? grassLightSprite : grassDarkSprite;
-            if (grassSprite != null)
+            var wImg = wizardObject.GetComponent<Image>();
+            if (wImg != null)
             {
-                laneImg.sprite = grassSprite;
-                laneImg.color = Color.white;
-            }
-            else
-            {
-                laneImg.color = even ? AppColors.GrassLight : AppColors.GrassDark;
-            }
-        }
-
-        // Set dirt road colors
-        foreach (var road in dirtRoads)
-            road.color = AppColors.DirtRoad;
-
-        // Set wizard sprites if available
-        for (int i = 0; i < wizardObjects.Count; i++)
-        {
-            if (wizardSprite != null)
-            {
-                var wImg = wizardObjects[i].GetComponent<Image>();
-                if (wImg != null)
-                {
-                    wImg.sprite = wizardSprite;
-                    wImg.color = Color.white;
-                }
+                wImg.sprite = wizardSprite;
+                wImg.color = Color.white;
             }
         }
     }
@@ -109,9 +82,12 @@ public class BattlefieldRenderer : MonoBehaviour
                 activeSnakeObjects[snake.id] = snakeRT;
             }
 
-            // Position snake
-            Vector2 pos = GameToScreenPosition(snake.xPosition, snake.lane);
+            // Position snake using polar coordinates
+            Vector2 pos = PolarToScreenPosition(snake.angleDeg, snake.distance);
             snakeRT.anchoredPosition = pos;
+
+            // Rotate snake to face wizard (inward)
+            snakeRT.localRotation = Quaternion.Euler(0, 0, snake.angleDeg + 180f);
 
             // Set sprite/color and size based on snake type
             Image snakeImage = snakeRT.GetComponent<Image>();
@@ -176,7 +152,7 @@ public class BattlefieldRenderer : MonoBehaviour
                 activeSpellObjects[spell.id] = spellRT;
             }
 
-            Vector2 pos = GameToScreenPosition(spell.xPosition, spell.lane);
+            Vector2 pos = PolarToScreenPosition(spell.angleDeg, spell.distance);
             spellRT.anchoredPosition = pos;
 
             Image spellImage = spellRT.GetComponent<Image>();
@@ -223,20 +199,21 @@ public class BattlefieldRenderer : MonoBehaviour
             gameOverOverlay.SetActive(bf.status == GameStatus.GameOver);
     }
 
-    private Vector2 GameToScreenPosition(float gameX, int lane)
+    private Vector2 PolarToScreenPosition(float angleDeg, float distance)
     {
         if (battlefieldPanel == null) return Vector2.zero;
 
         float panelWidth = battlefieldPanel.rect.width;
         float panelHeight = battlefieldPanel.rect.height;
 
-        float scaleX = panelWidth / SnakeSpellConstants.FieldWidth;
-        float laneHeight = panelHeight / SnakeSpellConstants.NumLanes;
+        float maxScreenRadius = Mathf.Min(panelWidth, panelHeight) / 2f * 0.9f;
+        float screenRadius = (distance / SnakeSpellConstants.FieldRadius) * maxScreenRadius;
 
-        float screenX = gameX * scaleX - panelWidth / 2f;
-        float screenY = panelHeight / 2f - (lane + 0.5f) * laneHeight;
+        float angleRad = angleDeg * Mathf.Deg2Rad;
+        float x = Mathf.Cos(angleRad) * screenRadius;
+        float y = Mathf.Sin(angleRad) * screenRadius;
 
-        return new Vector2(screenX, screenY);
+        return new Vector2(x, y);
     }
 
     // ── Sprite Lookup ──

--- a/UnityProject/BrainAcademy/Assets/Scripts/SnakeSpell/SnakeSpellController.cs
+++ b/UnityProject/BrainAcademy/Assets/Scripts/SnakeSpell/SnakeSpellController.cs
@@ -85,16 +85,16 @@ public class SnakeSpellController : MonoBehaviour
 
     private void UpdatePlaying(float dt)
     {
-        // Move snakes left
+        // Move snakes inward (decreasing distance)
         foreach (var snake in Battlefield.snakes)
-            snake.xPosition -= snake.speed * dt;
+            snake.distance -= snake.speed * dt;
 
-        // Move spells right
+        // Move spells outward (increasing distance)
         foreach (var spell in Battlefield.spells)
-            spell.xPosition += spell.speed * dt;
+            spell.distance += spell.speed * dt;
 
         // Check snakes reaching wizard
-        var reached = Battlefield.snakes.Where(s => s.xPosition <= SnakeSpellConstants.WizardX).ToList();
+        var reached = Battlefield.snakes.Where(s => s.distance <= SnakeSpellConstants.WizardHitRadius).ToList();
         foreach (var snake in reached)
             Battlefield.snakes.Remove(snake);
         Battlefield.lives -= reached.Count;
@@ -103,8 +103,8 @@ public class SnakeSpellController : MonoBehaviour
         var spellsToRemove = new HashSet<int>();
         foreach (var spell in Battlefield.spells)
         {
-            var target = Battlefield.snakes.Find(s => s.id == spell.targetSnakeId && s.lane == spell.lane);
-            if (target != null && spell.xPosition >= target.xPosition)
+            var target = Battlefield.snakes.Find(s => s.id == spell.targetSnakeId);
+            if (target != null && spell.distance >= target.distance)
             {
                 spellsToRemove.Add(spell.id);
                 target.hp -= 1;
@@ -116,7 +116,7 @@ public class SnakeSpellController : MonoBehaviour
                 }
             }
 
-            if (spell.xPosition > SnakeSpellConstants.FieldWidth)
+            if (spell.distance > SnakeSpellConstants.SpellDespawnRadius)
                 spellsToRemove.Add(spell.id);
         }
         Battlefield.spells.RemoveAll(s => spellsToRemove.Contains(s.id));
@@ -125,15 +125,15 @@ public class SnakeSpellController : MonoBehaviour
         spawnTimer -= dt;
         if (spawnTimer <= 0f && snakesSpawnedThisWave < totalSnakesThisWave)
         {
-            int lane = WaveGenerator.PickLane();
+            float angleDeg = WaveGenerator.PickAngle();
             SnakeType type = WaveGenerator.PickSnakeType(Battlefield.currentWave, Config);
             float speed = WaveGenerator.GetSnakeSpeed(type, Battlefield.currentWave, Config);
 
             Battlefield.snakes.Add(new SnakeData(
                 id: nextSnakeId++,
-                lane: lane,
+                angleDeg: angleDeg,
                 type: type,
-                xPosition: SnakeSpellConstants.FieldWidth,
+                distance: SnakeSpellConstants.FieldRadius,
                 hp: SnakeTypeData.GetBaseHp(type),
                 speed: speed
             ));
@@ -249,15 +249,15 @@ public class SnakeSpellController : MonoBehaviour
     {
         var nearestSnake = Battlefield.snakes
             .Where(s => s.hp > 0)
-            .OrderBy(s => s.xPosition)
+            .OrderBy(s => s.distance)
             .FirstOrDefault();
 
         if (nearestSnake == null) return;
 
         Battlefield.spells.Add(new SpellData(
             id: nextSpellId++,
-            lane: nearestSnake.lane,
-            xPosition: SnakeSpellConstants.WizardX,
+            angleDeg: nearestSnake.angleDeg,
+            distance: 0f,
             targetSnakeId: nearestSnake.id
         ));
     }

--- a/UnityProject/BrainAcademy/Assets/Scripts/SnakeSpell/WaveGenerator.cs
+++ b/UnityProject/BrainAcademy/Assets/Scripts/SnakeSpell/WaveGenerator.cs
@@ -25,8 +25,8 @@ public static class WaveGenerator
         return (config.baseSnakeSpeed + waveBonus) * SnakeTypeData.GetSpeedMultiplier(snakeType);
     }
 
-    public static int PickLane()
+    public static float PickAngle()
     {
-        return Random.Range(0, SnakeSpellConstants.NumLanes);
+        return Random.Range(0f, 360f);
     }
 }

--- a/UnityProject/BrainAcademy/Assets/Tests/EditMode/GameModelsTests.cs
+++ b/UnityProject/BrainAcademy/Assets/Tests/EditMode/GameModelsTests.cs
@@ -77,20 +77,20 @@ public class GameQuestionTests
 public class SnakeSpellConstantsTests
 {
     [Test]
-    public void FieldWidth_Is1000()
+    public void FieldRadius_Is500()
     {
-        Assert.AreEqual(1000f, SnakeSpellConstants.FieldWidth);
+        Assert.AreEqual(500f, SnakeSpellConstants.FieldRadius);
     }
 
     [Test]
-    public void NumLanes_Is3()
+    public void WizardHitRadius_IsPositive()
     {
-        Assert.AreEqual(3, SnakeSpellConstants.NumLanes);
+        Assert.Greater(SnakeSpellConstants.WizardHitRadius, 0f);
     }
 
     [Test]
-    public void WizardX_IsPositive()
+    public void SpellDespawnRadius_IsGreaterThanFieldRadius()
     {
-        Assert.Greater(SnakeSpellConstants.WizardX, 0f);
+        Assert.Greater(SnakeSpellConstants.SpellDespawnRadius, SnakeSpellConstants.FieldRadius);
     }
 }

--- a/UnityProject/BrainAcademy/Assets/Tests/EditMode/SnakeSpellModelsTests.cs
+++ b/UnityProject/BrainAcademy/Assets/Tests/EditMode/SnakeSpellModelsTests.cs
@@ -106,13 +106,13 @@ public class SnakeDataTests
     [Test]
     public void Constructor_SetsAllFields()
     {
-        var snake = new SnakeData(id: 5, lane: 2, type: SnakeType.Red,
-            xPosition: 500f, hp: 3, speed: 60f);
+        var snake = new SnakeData(id: 5, angleDeg: 135f, type: SnakeType.Red,
+            distance: 500f, hp: 3, speed: 60f);
 
         Assert.AreEqual(5, snake.id);
-        Assert.AreEqual(2, snake.lane);
+        Assert.AreEqual(135f, snake.angleDeg);
         Assert.AreEqual(SnakeType.Red, snake.type);
-        Assert.AreEqual(500f, snake.xPosition);
+        Assert.AreEqual(500f, snake.distance);
         Assert.AreEqual(3, snake.hp);
         Assert.AreEqual(60f, snake.speed);
     }

--- a/UnityProject/BrainAcademy/Assets/Tests/EditMode/WaveGeneratorTests.cs
+++ b/UnityProject/BrainAcademy/Assets/Tests/EditMode/WaveGeneratorTests.cs
@@ -87,4 +87,15 @@ public class WaveGeneratorTests
         var config = Difficulty.SuperHard.ToSnakeSpellConfig();
         Assert.AreEqual(SnakeType.Green, WaveGenerator.PickSnakeType(1, config));
     }
+
+    [Test]
+    public void PickAngle_ReturnsValueInRange()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            float angle = WaveGenerator.PickAngle();
+            Assert.GreaterOrEqual(angle, 0f);
+            Assert.Less(angle, 360f);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Replace the 3-lane left-to-right battlefield with a radial coordinate system where the wizard sits at screen center and snakes approach from 360 degrees
- SnakeData/SpellData now use polar coordinates (angleDeg/distance) instead of lane/xPosition; BattlefieldRenderer maps polar→screen via cos/sin
- SceneBuilderSnake builds a single centered wizard + background instead of 3-lane loop with dirt roads

Closes #9

## Results

### Tests
| Suite | Passed | Failed | Skipped | Total |
|-------|--------|--------|---------|-------|
| EditMode | 39 | 0 | 0 | 39 |

### Other measurable outcomes
- Precommit: all checks pass
- 9 files changed, 101 insertions, 149 deletions (net reduction)

## Test plan
- [ ] Run EditMode tests in Unity Editor — all pass
- [ ] Run Full Setup (Brain Academy → Setup → Run Full Setup) to regenerate SnakeSpellScene
- [ ] Visual verification in Unity Editor: wizard centered, snakes approach from all angles, spells travel outward
- [ ] Confirm adaptive difficulty still adjusts spawn rate correctly with radial movement

---
🤖 Agent: `blackhorse-win` / `.claude/worktrees/009`

🤖 Generated with [Claude Code](https://claude.com/claude-code)