### PR TITLE
Feature/ Support cloze and sentence insertion question types

### DIFF
--- a/UnityProject/BrainAcademy/Assets/Editor/Setup/SceneBuilderReading.cs
+++ b/UnityProject/BrainAcademy/Assets/Editor/Setup/SceneBuilderReading.cs
@@ -81,7 +81,7 @@ public static class SceneBuilderReading
         vlg.childControlHeight = true;
 
         var answerButtons = UIFactory.CreateAnswerButtons(
-            ansContainer.transform, PrefabFactory.AnswerButtonPrefab, 4);
+            ansContainer.transform, PrefabFactory.AnswerButtonPrefab, 7);
 
         // ── Feedback overlay ──────────────────────────────────────────────
         var (fbGo, fbComp, _) = UIFactory.CreateFeedbackOverlay(readingPanel.transform);
@@ -97,7 +97,9 @@ public static class SceneBuilderReading
         UIFactory.Wire(ctrl, "questionText", qText);
         UIFactory.WireList(ctrl, "answerButtons",
             new Object[] { answerButtons[0], answerButtons[1],
-                           answerButtons[2], answerButtons[3] });
+                           answerButtons[2], answerButtons[3],
+                           answerButtons[4], answerButtons[5],
+                           answerButtons[6] });
         UIFactory.Wire(ctrl, "feedbackOverlay", fbComp);
 
         EditorSceneManager.SaveScene(scene, "Assets/Scenes/SnakeSpellScene.unity");

--- a/UnityProject/BrainAcademy/Assets/Scripts/Questions/QuestionBankLoader.cs
+++ b/UnityProject/BrainAcademy/Assets/Scripts/Questions/QuestionBankLoader.cs
@@ -25,6 +25,12 @@ public class QuestionBankLoader
         public string title;
         public string type;
         public string text;
+        public JArray blanks;              // cloze
+        public JArray gaps;                // sentence_insertion: gap labels
+        public JArray sentences;           // sentence_insertion: sentence options
+        public JObject correctMapping;     // sentence_insertion: gap→sentence
+        public JToken extraSentence;       // sentence_insertion: extra (unused) sentence
+        public JObject gapReasoning;       // sentence_insertion: per-gap explanations
     }
 
     private readonly List<BankQuestion> allQuestions = new List<BankQuestion>();
@@ -40,7 +46,12 @@ public class QuestionBankLoader
             return;
         }
 
-        JObject root = JObject.Parse(json.text);
+        LoadFromJson(json.text);
+    }
+
+    public void LoadFromJson(string jsonText)
+    {
+        JObject root = JObject.Parse(jsonText);
         string version = root["meta"]?["version"]?.ToString() ?? "1.0";
 
         if (version.StartsWith("2"))
@@ -94,11 +105,26 @@ public class QuestionBankLoader
                     type = p["type"]?.ToString(),
                     text = p["text"]?.ToString()
                 };
+
+                if (pd.type == "cloze")
+                {
+                    pd.blanks = (JArray)p["blanks"];
+                }
+                else if (pd.type == "sentence_insertion")
+                {
+                    pd.gaps = (JArray)p["gaps"];
+                    pd.sentences = (JArray)p["sentences"];
+                    pd.correctMapping = (JObject)p["correct_mapping"];
+                    pd.extraSentence = p["extra_sentence"];
+                    pd.gapReasoning = (JObject)p["gap_reasoning"];
+                }
+
                 if (pd.id != null)
                     passages[pd.id] = pd;
             }
         }
 
+        // Load MCQ questions (from comprehension/poem passages)
         JArray questionArr = (JArray)reading["questions"];
         if (questionArr != null)
         {
@@ -108,6 +134,103 @@ public class QuestionBankLoader
                 bq.questionType = "long";
                 bq.passageId = item["passage_id"]?.ToString();
                 allQuestions.Add(bq);
+            }
+        }
+
+        // Generate questions from cloze and sentence insertion passages
+        GenerateClozeQuestions();
+        GenerateSentenceInsertionQuestions();
+    }
+
+    private void GenerateClozeQuestions()
+    {
+        foreach (var pd in passages.Values)
+        {
+            if (pd.type != "cloze" || pd.blanks == null) continue;
+
+            foreach (JToken blank in pd.blanks)
+            {
+                string blankId = blank["id"]?.ToString() ?? "";
+                int blankNum = blank["blank_number"]?.Value<int>() ?? 0;
+
+                var options = new List<string>();
+                JArray optArr = (JArray)blank["options"];
+                if (optArr != null)
+                {
+                    foreach (JToken opt in optArr)
+                        options.Add(opt.ToString());
+                }
+
+                allQuestions.Add(new BankQuestion
+                {
+                    id = blankId,
+                    questionType = "long",
+                    passageId = pd.id,
+                    question = $"Fill in blank {blankNum}: Which word best completes the sentence?",
+                    options = options,
+                    correctAnswer = blank["correct_answer"]?.ToString() ?? "",
+                    explanation = blank["reasoning"]?.ToString() ?? "",
+                });
+            }
+        }
+    }
+
+    private void GenerateSentenceInsertionQuestions()
+    {
+        foreach (var pd in passages.Values)
+        {
+            if (pd.type != "sentence_insertion" || pd.gaps == null
+                || pd.sentences == null || pd.correctMapping == null)
+                continue;
+
+            // Build sentence lookup: key (number or label) → display text
+            var sentenceTexts = new List<string>();
+            var sentenceKeys = new List<string>();
+            foreach (JToken s in pd.sentences)
+            {
+                string key = s["number"]?.ToString() ?? s["label"]?.ToString() ?? "";
+                string text = s["text"]?.ToString() ?? "";
+                sentenceKeys.Add(key);
+                sentenceTexts.Add(text);
+            }
+
+            // Build options list with labels
+            var options = new List<string>();
+            for (int i = 0; i < sentenceKeys.Count; i++)
+                options.Add($"{sentenceKeys[i]}. {sentenceTexts[i]}");
+
+            foreach (JToken gapToken in pd.gaps)
+            {
+                string gap = gapToken.ToString();
+                string questionId = $"{pd.id}_GAP_{gap}";
+
+                // Find correct sentence for this gap
+                JToken correctVal = pd.correctMapping[gap];
+                string correctKey = correctVal?.ToString() ?? "";
+
+                // Find the matching option text
+                string correctOption = "";
+                for (int i = 0; i < sentenceKeys.Count; i++)
+                {
+                    if (sentenceKeys[i] == correctKey)
+                    {
+                        correctOption = options[i];
+                        break;
+                    }
+                }
+
+                string reasoning = pd.gapReasoning?[gap]?.ToString() ?? "";
+
+                allQuestions.Add(new BankQuestion
+                {
+                    id = questionId,
+                    questionType = "long",
+                    passageId = pd.id,
+                    question = $"Which sentence best fits gap {gap}?",
+                    options = new List<string>(options),
+                    correctAnswer = correctOption,
+                    explanation = reasoning,
+                });
             }
         }
     }
@@ -280,6 +403,18 @@ public class QuestionBankLoader
                 explanation: bq.explanation
             )
         );
+    }
+
+    public int GetQuestionCount(string questionType = null)
+    {
+        if (questionType == null)
+            return allQuestions.Count;
+        return allQuestions.Count(q => q.questionType == questionType);
+    }
+
+    public int GetPassageCount()
+    {
+        return passages.Count;
     }
 
     public void Reset()

--- a/UnityProject/BrainAcademy/Assets/Tests/EditMode/QuestionBankLoaderTests.cs
+++ b/UnityProject/BrainAcademy/Assets/Tests/EditMode/QuestionBankLoaderTests.cs
@@ -1,0 +1,334 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+public class QuestionBankLoaderTests
+{
+    private const string MinimalV2Json = @"{
+        ""meta"": { ""version"": ""2.0"" },
+        ""mathematical_reasoning"": [],
+        ""thinking_skills"": [],
+        ""reading"": {
+            ""passages"": [
+                {
+                    ""id"": ""COMP_1"",
+                    ""title"": ""Test Passage"",
+                    ""type"": ""comprehension"",
+                    ""text"": ""A simple passage.""
+                }
+            ],
+            ""questions"": [
+                {
+                    ""id"": ""MCQ_1"",
+                    ""passage_id"": ""COMP_1"",
+                    ""question"": ""What is the passage about?"",
+                    ""options"": [""A"", ""B"", ""C"", ""D""],
+                    ""correct_answer"": ""A"",
+                    ""explanation"": ""Correct.""
+                }
+            ]
+        }
+    }";
+
+    private const string ClozeJson = @"{
+        ""meta"": { ""version"": ""2.0"" },
+        ""mathematical_reasoning"": [],
+        ""thinking_skills"": [],
+        ""reading"": {
+            ""passages"": [
+                {
+                    ""id"": ""CLOZE_1"",
+                    ""title"": ""Cloze Test"",
+                    ""type"": ""cloze"",
+                    ""text"": ""He could barely ...[blank 1]... himself. She ...[blank 2]... away."",
+                    ""blanks"": [
+                        {
+                            ""id"": ""C1_B1"",
+                            ""blank_number"": 1,
+                            ""options"": [""resist"", ""contain"", ""keep"", ""hold""],
+                            ""correct_index"": 1,
+                            ""correct_answer"": ""contain"",
+                            ""reasoning"": ""Contain oneself is the correct idiom.""
+                        },
+                        {
+                            ""id"": ""C1_B2"",
+                            ""blank_number"": 2,
+                            ""options"": [""ran"", ""walked"", ""drove"", ""flew""],
+                            ""correct_index"": 1,
+                            ""correct_answer"": ""walked"",
+                            ""reasoning"": ""Walked fits the context.""
+                        }
+                    ]
+                }
+            ],
+            ""questions"": []
+        }
+    }";
+
+    private const string SentenceInsertionNumberJson = @"{
+        ""meta"": { ""version"": ""2.0"" },
+        ""mathematical_reasoning"": [],
+        ""thinking_skills"": [],
+        ""reading"": {
+            ""passages"": [
+                {
+                    ""id"": ""SI_1"",
+                    ""title"": ""Sentence Insertion Test"",
+                    ""type"": ""sentence_insertion"",
+                    ""text"": ""Australia is a land of birds. A ............ B ............"",
+                    ""gaps"": [""A"", ""B""],
+                    ""sentences"": [
+                        { ""number"": 1, ""text"": ""The birds are shy."" },
+                        { ""number"": 2, ""text"": ""They live in trees."" },
+                        { ""number"": 3, ""text"": ""This is extra."" }
+                    ],
+                    ""correct_mapping"": { ""A"": 1, ""B"": 2 },
+                    ""extra_sentence"": 3,
+                    ""gap_reasoning"": {
+                        ""A"": ""Gap A needs shy birds."",
+                        ""B"": ""Gap B needs trees.""
+                    }
+                }
+            ],
+            ""questions"": []
+        }
+    }";
+
+    private const string SentenceInsertionLabelJson = @"{
+        ""meta"": { ""version"": ""2.0"" },
+        ""mathematical_reasoning"": [],
+        ""thinking_skills"": [],
+        ""reading"": {
+            ""passages"": [
+                {
+                    ""id"": ""SI_2"",
+                    ""title"": ""Label Format Test"",
+                    ""type"": ""sentence_insertion"",
+                    ""text"": ""Text with gaps. 12 ............ 13 ............"",
+                    ""gaps"": [""12"", ""13""],
+                    ""sentences"": [
+                        { ""label"": ""A"", ""text"": ""First option."" },
+                        { ""label"": ""B"", ""text"": ""Second option."" },
+                        { ""label"": ""C"", ""text"": ""Third option."" }
+                    ],
+                    ""correct_mapping"": { ""12"": ""A"", ""13"": ""C"" },
+                    ""extra_sentence"": ""B"",
+                    ""gap_reasoning"": {
+                        ""12"": ""Reason for gap 12."",
+                        ""13"": ""Reason for gap 13.""
+                    }
+                }
+            ],
+            ""questions"": []
+        }
+    }";
+
+    [Test]
+    public void LoadFromJson_McqOnly_LoadsCorrectly()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(MinimalV2Json);
+
+        Assert.AreEqual(1, loader.GetQuestionCount("long"));
+        Assert.AreEqual(1, loader.GetPassageCount());
+    }
+
+    [Test]
+    public void LoadFromJson_Cloze_GeneratesQuestionPerBlank()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(ClozeJson);
+
+        Assert.AreEqual(2, loader.GetQuestionCount("long"));
+    }
+
+    [Test]
+    public void LoadFromJson_Cloze_CorrectAnswerMatches()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(ClozeJson);
+
+        // Get both cloze questions
+        var q1 = loader.GetReadingQuestion();
+        Assert.IsNotNull(q1);
+        Assert.AreEqual("cloze", q1.passageType);
+
+        // One of the two blanks should be returned
+        bool isBlank1 = q1.question.correctAnswer == "contain";
+        bool isBlank2 = q1.question.correctAnswer == "walked";
+        Assert.IsTrue(isBlank1 || isBlank2, "Correct answer should match one of the blanks");
+
+        // Get the second
+        var q2 = loader.GetReadingQuestionForPassage("CLOZE_1");
+        Assert.IsNotNull(q2);
+        Assert.AreEqual("cloze", q2.passageType);
+    }
+
+    [Test]
+    public void LoadFromJson_Cloze_QuestionTextIncludesBlankNumber()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(ClozeJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.IsTrue(q.question.questionText.Contains("Fill in blank"),
+            "Cloze question text should reference blank number");
+    }
+
+    [Test]
+    public void LoadFromJson_Cloze_HasFourOptions()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(ClozeJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.AreEqual(4, q.question.answers.Count);
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_NumberFormat_GeneratesQuestionPerGap()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionNumberJson);
+
+        Assert.AreEqual(2, loader.GetQuestionCount("long"));
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_NumberFormat_CorrectAnswerMatches()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionNumberJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.IsNotNull(q);
+        Assert.AreEqual("sentence_insertion", q.passageType);
+
+        // Correct answer should be a formatted sentence option
+        bool matchesSentence1 = q.question.correctAnswer.Contains("The birds are shy.");
+        bool matchesSentence2 = q.question.correctAnswer.Contains("They live in trees.");
+        Assert.IsTrue(matchesSentence1 || matchesSentence2,
+            $"Correct answer '{q.question.correctAnswer}' should match a sentence");
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_HasAllSentencesAsOptions()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionNumberJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.AreEqual(3, q.question.answers.Count, "Should have all sentences as options");
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_LabelFormat_GeneratesQuestions()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionLabelJson);
+
+        Assert.AreEqual(2, loader.GetQuestionCount("long"));
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_LabelFormat_CorrectAnswerMatches()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionLabelJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.IsNotNull(q);
+        Assert.AreEqual("sentence_insertion", q.passageType);
+
+        // One of the gap answers should match
+        bool matchesA = q.question.correctAnswer.Contains("First option.");
+        bool matchesC = q.question.correctAnswer.Contains("Third option.");
+        Assert.IsTrue(matchesA || matchesC,
+            $"Correct answer '{q.question.correctAnswer}' should match gap mapping");
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_QuestionTextReferencesGap()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionNumberJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.IsTrue(q.question.questionText.Contains("gap"),
+            "Question should reference the gap");
+    }
+
+    [Test]
+    public void LoadFromJson_SentenceInsertion_HasExplanation()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(SentenceInsertionNumberJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.IsFalse(string.IsNullOrEmpty(q.question.explanation),
+            "Sentence insertion questions should have reasoning as explanation");
+    }
+
+    [Test]
+    public void LoadFromJson_Mixed_CountsAllQuestionTypes()
+    {
+        // Build JSON with both MCQ and cloze
+        string mixedJson = @"{
+            ""meta"": { ""version"": ""2.0"" },
+            ""mathematical_reasoning"": [],
+            ""thinking_skills"": [],
+            ""reading"": {
+                ""passages"": [
+                    {
+                        ""id"": ""COMP_1"",
+                        ""title"": ""Comprehension"",
+                        ""type"": ""comprehension"",
+                        ""text"": ""A passage.""
+                    },
+                    {
+                        ""id"": ""CLOZE_1"",
+                        ""title"": ""Cloze"",
+                        ""type"": ""cloze"",
+                        ""text"": ""Fill ...[blank 1]..."",
+                        ""blanks"": [
+                            {
+                                ""id"": ""B1"",
+                                ""blank_number"": 1,
+                                ""options"": [""a"", ""b"", ""c"", ""d""],
+                                ""correct_answer"": ""b"",
+                                ""reasoning"": ""Because.""
+                            }
+                        ]
+                    }
+                ],
+                ""questions"": [
+                    {
+                        ""id"": ""Q1"",
+                        ""passage_id"": ""COMP_1"",
+                        ""question"": ""What?"",
+                        ""options"": [""A"", ""B""],
+                        ""correct_answer"": ""A"",
+                        ""explanation"": ""Yes.""
+                    }
+                ]
+            }
+        }";
+
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(mixedJson);
+
+        // 1 MCQ + 1 cloze blank = 2 long questions
+        Assert.AreEqual(2, loader.GetQuestionCount("long"));
+        Assert.AreEqual(2, loader.GetPassageCount());
+    }
+
+    [Test]
+    public void LoadFromJson_Cloze_PassageTextContainsBlanks()
+    {
+        var loader = new QuestionBankLoader();
+        loader.LoadFromJson(ClozeJson);
+
+        var q = loader.GetReadingQuestion();
+        Assert.IsTrue(q.passageText.Contains("[blank"),
+            "Cloze passage text should contain blank markers");
+    }
+}


### PR DESCRIPTION
## Summary
- Extend `QuestionBankLoader` to parse cloze blanks and sentence insertion gaps from reading passages, converting them into standard `ReadingComprehension` questions
- Each cloze blank becomes an MCQ with 4 word options; each sentence insertion gap becomes an MCQ with all sentences as options
- Increase reading panel answer buttons from 4 to 7 to accommodate sentence insertion (7 sentence options)

Closes #12

## Results

### Tests
| Suite | Passed | Failed | Skipped | Total |
|-------|--------|--------|---------|-------|
| Pre-commit | 4/4 | 0 | 0 | 4 |
| QuestionBankLoaderTests (new) | 14 | 0 | 0 | 14 |

### Other measurable outcomes
- Precommit: all checks pass
- New question types available: 8 cloze blanks (1 passage), 14 sentence insertion gaps (3 passages)
- Reading question pool expands from MCQ-only to MCQ + cloze + sentence insertion

## Test plan
- [ ] CI Lint and Question Bank checks pass
- [ ] New EditMode tests pass (QuestionBankLoaderTests: 14 tests)
- [ ] Existing EditMode tests still pass
- [ ] Cloze questions render with passage text containing blank markers and 4 word options
- [ ] Sentence insertion questions render with passage text and 7 sentence options
- [ ] Both P1-style (number keys) and P2/P3-style (label keys) sentence formats work

**Agent:** blackhorse-win / main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)